### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 #Nussbaum-Backend
 
 [![Build Status](https://travis-ci.org/ikarulus/Nussbaum-Backend.svg?branch=master)](https://travis-ci.org/ikarulus/Nussbaum-Backend)
+![issue_stats](https://img.shields.io/badge/issues%20closed%20in-about%206%20hours-green.svg?style=flat-square)
 
 Usage: <https://gist.github.com/ikarulus/c57ae21442201fae89fa194c1e021f6d> (de)
 

--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Usage: <https://gist.github.com/ikarulus/c57ae21442201fae89fa194c1e021f6d> (de)
 ##Install (using Node Package Manager):
 1. `git clone https://github.com/ikarulus/Nussbaum-Backend.git`
 2. `cd` in your "Nussbaum-Backend" directory
-3. `npm install`
+3. `npm install` (if not available simply run `sudo apt-get install nodejs npm`)
 4. Launch via `node app.js` or `npm start`


### PR DESCRIPTION
added the option how to install Nussbaum-Backend without having `npm` respective `nodejs` previously installed...
